### PR TITLE
Add basic frontend UI for projects and tasks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+node_modules
+.env
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Build
+/dist
+/build
+
+# Misc
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## v1.0.0
+- Initial public release with user authentication, project management, and task tracking.
+- Supports customizable status columns, project members, subtasks, comments, and due dates.
+- Includes basic frontend served from Node server and Vercel configuration for deployment.

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ npm start
 - `GET /projects/:id/statuses` – list status columns for a project.
 - `PATCH /projects/:id/statuses/:statusId` – rename a status column (owner only).
 - `DELETE /projects/:id/statuses/:statusId` – remove a status column and reassign tasks (owner only).
-- `POST /projects/:id/tasks` – `{ "title": "...", "statusId?": number }` with `Authorization: Bearer <token>` → create task in project.
-- `GET /projects/:id/tasks` – list tasks for a project (each task has `id`, `title`, `completed` and `statusId`).
-- `PATCH /projects/:id/tasks/:taskId` – update task fields like `title`, `completed` or `statusId`.
+- `POST /projects/:id/tasks` – `{ "title": "...", "statusId?": number, "dueDate?": "YYYY-MM-DD" }` with `Authorization: Bearer <token>` → create task in project.
+- `GET /projects/:id/tasks` – list tasks for a project (each task has `id`, `title`, `completed`, `statusId` and optional `dueDate`).
+- `PATCH /projects/:id/tasks/:taskId` – update task fields like `title`, `completed`, `statusId` or `dueDate`.
 - `DELETE /projects/:id/tasks/:taskId` – remove a task from a project.
 - `POST /projects/:id/tasks/:taskId/subtasks` – `{ "title": "..." }` with `Authorization: Bearer <token>` → add subtask to a task.
 - `GET /projects/:id/tasks/:taskId/subtasks` – list subtasks for a task (each subtask has `id`, `title` and `completed`).
@@ -80,6 +80,5 @@ The project includes a `vercel.json` configuration so it can be deployed to [Ver
 To deploy:
 
 ```bash
-npm run install:all
-npx vercel
+npm run deploy
 ```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,85 @@
-# test
+# Project Management App
+
+This repository contains a minimal starting point for a multi-user project management application.
+
+## Structure
+
+- `backend/` – Node.js server with in-memory storage and basic routes for authentication and projects.
+- `frontend/` – Static HTML/JS placeholder for the client side.
+
+## Backend
+
+Run the server:
+
+```
+cd backend
+npm start
+```
+
+### API
+
+- `POST /auth/register` – `{ "username": "...", "password": "..." }` → create user.
+- `POST /auth/login` – `{ "username": "...", "password": "..." }` → returns `{ token }`.
+- `GET /auth/me` – with `Authorization: Bearer <token>` → returns current user info.
+- `POST /auth/logout` – with `Authorization: Bearer <token>` → invalidate the current session.
+- `POST /projects` – `{ "name": "..." }` with `Authorization: Bearer <token>` → create project (creator becomes owner).
+- `GET /projects` – list projects where the current user is a member.
+- `PATCH /projects/:id` – update project fields like `name` (owner only).
+- `DELETE /projects/:id` – remove a project and all its tasks (owner only).
+- `POST /projects/:id/members` – `{ "username": "..." }` with `Authorization: Bearer <token>` (owner only) → invite an existing user to the project.
+- `GET /projects/:id/members` – list project members (must belong to the project).
+- `DELETE /projects/:id/members/:userId` – remove a member from the project (owner only).
+- `POST /projects/:id/statuses` – `{ "name": "..." }` with `Authorization: Bearer <token>` (owner only) → add a task status column.
+- `GET /projects/:id/statuses` – list status columns for a project.
+- `PATCH /projects/:id/statuses/:statusId` – rename a status column (owner only).
+- `DELETE /projects/:id/statuses/:statusId` – remove a status column and reassign tasks (owner only).
+- `POST /projects/:id/tasks` – `{ "title": "...", "statusId?": number }` with `Authorization: Bearer <token>` → create task in project.
+- `GET /projects/:id/tasks` – list tasks for a project (each task has `id`, `title`, `completed` and `statusId`).
+- `PATCH /projects/:id/tasks/:taskId` – update task fields like `title`, `completed` or `statusId`.
+- `DELETE /projects/:id/tasks/:taskId` – remove a task from a project.
+- `POST /projects/:id/tasks/:taskId/subtasks` – `{ "title": "..." }` with `Authorization: Bearer <token>` → add subtask to a task.
+- `GET /projects/:id/tasks/:taskId/subtasks` – list subtasks for a task (each subtask has `id`, `title` and `completed`).
+- `PATCH /projects/:id/tasks/:taskId/subtasks/:subtaskId` – update subtask fields like `title` or `completed`.
+- `DELETE /projects/:id/tasks/:taskId/subtasks/:subtaskId` – remove a subtask from a task.
+- `POST /projects/:id/tasks/:taskId/comments` – `{ "text": "..." }` with `Authorization: Bearer <token>` → add comment to a task.
+- `GET /projects/:id/tasks/:taskId/comments` – list comments for a task (each comment has `id`, `userId` and `text`).
+- `PATCH /projects/:id/tasks/:taskId/comments/:commentId` – update a comment's `text` (only its author).
+- `DELETE /projects/:id/tasks/:taskId/comments/:commentId` – remove a comment (only its author).
+
+All data is stored in memory and clears on restart.
+
+## Frontend
+
+Serve the static page:
+
+```
+cd frontend
+npm start
+```
+
+The app at [http://localhost:8080](http://localhost:8080) now provides a basic interface to register or log in, create
+projects, and add tasks. All requests are sent to the backend via relative `/api` paths so the same build works when
+deployed to Vercel.
+
+## Development
+
+From the repository root you can manage both services:
+
+```bash
+npm run install:all   # install dependencies for backend and frontend
+npm test              # run tests for both parts
+npm start             # launch backend (port 3000) and frontend (port 8080)
+```
+
+Each subdirectory also contains its own `package.json` with individual scripts like `npm start` and `npm test`.
+
+## Deployment
+
+The project includes a `vercel.json` configuration so it can be deployed to [Vercel](https://vercel.com). The static frontend is served from the `frontend` directory, and the backend is exposed as a serverless function under `/api`.
+
+To deploy:
+
+```bash
+npm run install:all
+npx vercel
+```

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,6 @@
+const handler = require('../backend/src/index.js');
+
+module.exports = (req, res) => {
+  req.url = req.url.replace(/^\/api/, '') || '/';
+  handler(req, res);
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "backend",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "Project management backend",
+  "main": "src/index.js",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node src/index.js",
+    "test": "echo \"No tests\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -379,7 +379,7 @@ const requestListener = async (req, res) => {
     }
     try {
       const body = await parseBody(req);
-      const { title, statusId } = body;
+      const { title, statusId, dueDate } = body;
       if (!title) {
         return send(res, 400, { error: 'title required' });
       }
@@ -387,7 +387,14 @@ const requestListener = async (req, res) => {
       if (!status) {
         status = statuses.find(s => s.projectId === projectId);
       }
-      const task = { id: nextTaskId++, projectId, title, completed: false, statusId: status ? status.id : undefined };
+      const task = {
+        id: nextTaskId++,
+        projectId,
+        title,
+        completed: false,
+        statusId: status ? status.id : undefined,
+        dueDate,
+      };
       tasks.push(task);
       return send(res, 201, task);
     } catch (err) {
@@ -439,6 +446,9 @@ const requestListener = async (req, res) => {
           return send(res, 400, { error: 'invalid status' });
         }
         task.statusId = status.id;
+      }
+      if (body.dueDate !== undefined) {
+         task.dueDate = body.dueDate;
       }
       return send(res, 200, task);
     } catch (err) {

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,0 +1,700 @@
+const http = require('http');
+
+const users = [];
+let nextUserId = 1;
+const sessions = new Map();
+const projects = [];
+let nextProjectId = 1;
+const tasks = [];
+let nextTaskId = 1;
+const subtasks = [];
+let nextSubtaskId = 1;
+const comments = [];
+let nextCommentId = 1;
+const statuses = [];
+let nextStatusId = 1;
+
+const parseBody = (req) => new Promise((resolve, reject) => {
+  let data = '';
+  req.on('data', chunk => {
+    data += chunk;
+  });
+  req.on('end', () => {
+    try {
+      const json = data ? JSON.parse(data) : {};
+      resolve(json);
+    } catch (err) {
+      reject(err);
+    }
+  });
+});
+
+const authenticate = (req) => {
+  const auth = req.headers['authorization'] || '';
+  const token = auth.split(' ')[1];
+  if (token && sessions.has(token)) {
+    const userId = sessions.get(token);
+    return users.find(u => u.id === userId) || null;
+  }
+  return null;
+};
+
+const send = (res, code, payload) => {
+  res.writeHead(code);
+  res.end(JSON.stringify(payload));
+};
+
+const requestListener = async (req, res) => {
+  res.setHeader('Content-Type', 'application/json');
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,PATCH,DELETE,OPTIONS');
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204);
+    return res.end();
+  }
+
+  if (req.method === 'GET' && req.url === '/') {
+    return send(res, 200, { message: 'API running' });
+  }
+
+  if (req.method === 'POST' && req.url === '/auth/register') {
+    try {
+      const body = await parseBody(req);
+      const { username, password } = body;
+      if (!username || !password) {
+        return send(res, 400, { error: 'username and password required' });
+      }
+      if (users.some(u => u.username === username)) {
+        return send(res, 409, { error: 'user exists' });
+      }
+      const user = { id: nextUserId++, username, password };
+      users.push(user);
+      return send(res, 201, { id: user.id, username: user.username });
+    } catch (err) {
+      return send(res, 400, { error: 'invalid json' });
+    }
+  }
+
+  if (req.method === 'POST' && req.url === '/auth/login') {
+    try {
+      const body = await parseBody(req);
+      const { username, password } = body;
+      const user = users.find(u => u.username === username && u.password === password);
+      if (!user) {
+        return send(res, 401, { error: 'invalid credentials' });
+      }
+      const token = Math.random().toString(36).slice(2);
+      sessions.set(token, user.id);
+      return send(res, 200, { token });
+    } catch (err) {
+      return send(res, 400, { error: 'invalid json' });
+    }
+  }
+
+  if (req.method === 'POST' && req.url === '/auth/logout') {
+    const auth = req.headers['authorization'] || '';
+    const token = auth.split(' ')[1];
+    if (token && sessions.has(token)) {
+      sessions.delete(token);
+      res.writeHead(204);
+      return res.end();
+    }
+    return send(res, 401, { error: 'invalid token' });
+  }
+
+  if (req.method === 'GET' && req.url === '/auth/me') {
+    const user = authenticate(req);
+    if (!user) {
+      return send(res, 401, { error: 'unauthorized' });
+    }
+    return send(res, 200, { id: user.id, username: user.username });
+  }
+
+  if (req.method === 'POST' && req.url === '/projects') {
+    const user = authenticate(req);
+    if (!user) {
+      return send(res, 401, { error: 'unauthorized' });
+    }
+    try {
+      const body = await parseBody(req);
+      const { name } = body;
+      if (!name) {
+        return send(res, 400, { error: 'name required' });
+      }
+      const project = { id: nextProjectId++, name, ownerId: user.id, members: [user.id] };
+      projects.push(project);
+      const defaults = ['todo', 'in-progress', 'done'].map(name => ({ id: nextStatusId++, projectId: project.id, name }));
+      statuses.push(...defaults);
+      return send(res, 201, project);
+    } catch (err) {
+      return send(res, 400, { error: 'invalid json' });
+    }
+  }
+
+  if (req.method === 'GET' && req.url === '/projects') {
+    const user = authenticate(req);
+    if (!user) {
+      return send(res, 401, { error: 'unauthorized' });
+    }
+    const userProjects = projects.filter(p => p.members.includes(user.id));
+    return send(res, 200, userProjects);
+  }
+
+  const singleProjectMatch = req.url.match(/^\/projects\/(\d+)$/);
+  if (singleProjectMatch && req.method === 'PATCH') {
+    const user = authenticate(req);
+    if (!user) {
+      return send(res, 401, { error: 'unauthorized' });
+    }
+    const projectId = parseInt(singleProjectMatch[1], 10);
+    const project = projects.find(p => p.id === projectId && p.ownerId === user.id);
+    if (!project) {
+      return send(res, 404, { error: 'project not found' });
+    }
+    try {
+      const body = await parseBody(req);
+      if (body.name !== undefined) {
+        project.name = body.name;
+      }
+      return send(res, 200, project);
+    } catch (err) {
+      return send(res, 400, { error: 'invalid json' });
+    }
+  }
+
+  if (singleProjectMatch && req.method === 'DELETE') {
+    const user = authenticate(req);
+    if (!user) {
+      return send(res, 401, { error: 'unauthorized' });
+    }
+    const projectId = parseInt(singleProjectMatch[1], 10);
+    const index = projects.findIndex(p => p.id === projectId && p.ownerId === user.id);
+    if (index === -1) {
+      return send(res, 404, { error: 'project not found' });
+    }
+    projects.splice(index, 1);
+
+    for (let i = tasks.length - 1; i >= 0; i--) {
+      if (tasks[i].projectId === projectId) {
+        const removedTaskId = tasks[i].id;
+        tasks.splice(i, 1);
+        for (let j = subtasks.length - 1; j >= 0; j--) {
+          if (subtasks[j].taskId === removedTaskId) {
+            subtasks.splice(j, 1);
+          }
+        }
+        for (let k = comments.length - 1; k >= 0; k--) {
+          if (comments[k].taskId === removedTaskId) {
+            comments.splice(k, 1);
+          }
+        }
+      }
+    }
+
+    for (let s = statuses.length - 1; s >= 0; s--) {
+      if (statuses[s].projectId === projectId) {
+        statuses.splice(s, 1);
+      }
+    }
+
+    res.writeHead(204);
+    return res.end();
+  }
+
+  const projectMembersMatch = req.url.match(/^\/projects\/(\d+)\/members$/);
+  if (projectMembersMatch && req.method === 'POST') {
+    const user = authenticate(req);
+    if (!user) {
+      return send(res, 401, { error: 'unauthorized' });
+    }
+    const projectId = parseInt(projectMembersMatch[1], 10);
+    const project = projects.find(p => p.id === projectId && p.ownerId === user.id);
+    if (!project) {
+      return send(res, 404, { error: 'project not found' });
+    }
+    try {
+      const body = await parseBody(req);
+      const { username } = body;
+      if (!username) {
+        return send(res, 400, { error: 'username required' });
+      }
+      const member = users.find(u => u.username === username);
+      if (!member) {
+        return send(res, 404, { error: 'user not found' });
+      }
+      if (!project.members.includes(member.id)) {
+        project.members.push(member.id);
+      }
+      return send(res, 201, { id: member.id, username: member.username });
+    } catch (err) {
+      return send(res, 400, { error: 'invalid json' });
+    }
+  }
+
+  if (projectMembersMatch && req.method === 'GET') {
+    const user = authenticate(req);
+    if (!user) {
+      return send(res, 401, { error: 'unauthorized' });
+    }
+    const projectId = parseInt(projectMembersMatch[1], 10);
+    const project = projects.find(p => p.id === projectId && p.members.includes(user.id));
+    if (!project) {
+      return send(res, 404, { error: 'project not found' });
+    }
+    const list = project.members.map(id => {
+      const u = users.find(usr => usr.id === id);
+      return { id: u.id, username: u.username };
+    });
+    return send(res, 200, list);
+  }
+
+  const singleMemberMatch = req.url.match(/^\/projects\/(\d+)\/members\/(\d+)$/);
+  if (singleMemberMatch && req.method === 'DELETE') {
+    const user = authenticate(req);
+    if (!user) {
+      return send(res, 401, { error: 'unauthorized' });
+    }
+    const projectId = parseInt(singleMemberMatch[1], 10);
+    const memberId = parseInt(singleMemberMatch[2], 10);
+    const project = projects.find(p => p.id === projectId && p.ownerId === user.id);
+    if (!project) {
+      return send(res, 404, { error: 'project not found' });
+    }
+    if (memberId === project.ownerId) {
+      return send(res, 400, { error: 'cannot remove owner' });
+    }
+    const index = project.members.indexOf(memberId);
+    if (index === -1) {
+      return send(res, 404, { error: 'member not found' });
+    }
+    project.members.splice(index, 1);
+    res.writeHead(204);
+    return res.end();
+  }
+
+  const projectStatusesMatch = req.url.match(/^\/projects\/(\d+)\/statuses$/);
+  if (projectStatusesMatch && req.method === 'POST') {
+    const user = authenticate(req);
+    if (!user) {
+      return send(res, 401, { error: 'unauthorized' });
+    }
+    const projectId = parseInt(projectStatusesMatch[1], 10);
+    const project = projects.find(p => p.id === projectId && p.ownerId === user.id);
+    if (!project) {
+      return send(res, 404, { error: 'project not found' });
+    }
+    try {
+      const body = await parseBody(req);
+      const { name } = body;
+      if (!name) {
+        return send(res, 400, { error: 'name required' });
+      }
+      const status = { id: nextStatusId++, projectId, name };
+      statuses.push(status);
+      return send(res, 201, status);
+    } catch (err) {
+      return send(res, 400, { error: 'invalid json' });
+    }
+  }
+
+  if (projectStatusesMatch && req.method === 'GET') {
+    const user = authenticate(req);
+    if (!user) {
+      return send(res, 401, { error: 'unauthorized' });
+    }
+    const projectId = parseInt(projectStatusesMatch[1], 10);
+    const project = projects.find(p => p.id === projectId && p.members.includes(user.id));
+    if (!project) {
+      return send(res, 404, { error: 'project not found' });
+    }
+    const list = statuses.filter(s => s.projectId === projectId);
+    return send(res, 200, list);
+  }
+
+  const singleStatusMatch = req.url.match(/^\/projects\/(\d+)\/statuses\/(\d+)$/);
+  if (singleStatusMatch && req.method === 'PATCH') {
+    const user = authenticate(req);
+    if (!user) {
+      return send(res, 401, { error: 'unauthorized' });
+    }
+    const projectId = parseInt(singleStatusMatch[1], 10);
+    const statusId = parseInt(singleStatusMatch[2], 10);
+    const project = projects.find(p => p.id === projectId && p.ownerId === user.id);
+    if (!project) {
+      return send(res, 404, { error: 'project not found' });
+    }
+    const status = statuses.find(s => s.id === statusId && s.projectId === projectId);
+    if (!status) {
+      return send(res, 404, { error: 'status not found' });
+    }
+    try {
+      const body = await parseBody(req);
+      if (body.name !== undefined) {
+        status.name = body.name;
+      }
+      return send(res, 200, status);
+    } catch (err) {
+      return send(res, 400, { error: 'invalid json' });
+    }
+  }
+
+  if (singleStatusMatch && req.method === 'DELETE') {
+    const user = authenticate(req);
+    if (!user) {
+      return send(res, 401, { error: 'unauthorized' });
+    }
+    const projectId = parseInt(singleStatusMatch[1], 10);
+    const statusId = parseInt(singleStatusMatch[2], 10);
+    const project = projects.find(p => p.id === projectId && p.ownerId === user.id);
+    if (!project) {
+      return send(res, 404, { error: 'project not found' });
+    }
+    const index = statuses.findIndex(s => s.id === statusId && s.projectId === projectId);
+    if (index === -1) {
+      return send(res, 404, { error: 'status not found' });
+    }
+    const fallback = statuses.find(s => s.projectId === projectId && s.id !== statusId);
+    for (const t of tasks) {
+      if (t.projectId === projectId && t.statusId === statusId) {
+        t.statusId = fallback ? fallback.id : undefined;
+      }
+    }
+    statuses.splice(index, 1);
+    res.writeHead(204);
+    return res.end();
+  }
+
+  const projectTasksMatch = req.url.match(/^\/projects\/(\d+)\/tasks$/);
+  if (projectTasksMatch && req.method === 'POST') {
+    const user = authenticate(req);
+    if (!user) {
+      return send(res, 401, { error: 'unauthorized' });
+    }
+    const projectId = parseInt(projectTasksMatch[1], 10);
+    const project = projects.find(p => p.id === projectId && p.members.includes(user.id));
+    if (!project) {
+      return send(res, 404, { error: 'project not found' });
+    }
+    try {
+      const body = await parseBody(req);
+      const { title, statusId } = body;
+      if (!title) {
+        return send(res, 400, { error: 'title required' });
+      }
+      let status = statuses.find(s => s.id === statusId && s.projectId === projectId);
+      if (!status) {
+        status = statuses.find(s => s.projectId === projectId);
+      }
+      const task = { id: nextTaskId++, projectId, title, completed: false, statusId: status ? status.id : undefined };
+      tasks.push(task);
+      return send(res, 201, task);
+    } catch (err) {
+      return send(res, 400, { error: 'invalid json' });
+    }
+  }
+
+  if (projectTasksMatch && req.method === 'GET') {
+    const user = authenticate(req);
+    if (!user) {
+      return send(res, 401, { error: 'unauthorized' });
+    }
+    const projectId = parseInt(projectTasksMatch[1], 10);
+    const project = projects.find(p => p.id === projectId && p.members.includes(user.id));
+    if (!project) {
+      return send(res, 404, { error: 'project not found' });
+    }
+    const projectTasks = tasks.filter(t => t.projectId === projectId);
+    return send(res, 200, projectTasks);
+  }
+
+  const singleTaskMatch = req.url.match(/^\/projects\/(\d+)\/tasks\/(\d+)$/);
+  if (singleTaskMatch && req.method === 'PATCH') {
+    const user = authenticate(req);
+    if (!user) {
+      return send(res, 401, { error: 'unauthorized' });
+    }
+    const projectId = parseInt(singleTaskMatch[1], 10);
+    const taskId = parseInt(singleTaskMatch[2], 10);
+    const project = projects.find(p => p.id === projectId && p.members.includes(user.id));
+    if (!project) {
+      return send(res, 404, { error: 'project not found' });
+    }
+    const task = tasks.find(t => t.id === taskId && t.projectId === projectId);
+    if (!task) {
+      return send(res, 404, { error: 'task not found' });
+    }
+    try {
+      const body = await parseBody(req);
+      if (body.title !== undefined) {
+        task.title = body.title;
+      }
+      if (body.completed !== undefined) {
+        task.completed = !!body.completed;
+      }
+      if (body.statusId !== undefined) {
+        const status = statuses.find(s => s.id === body.statusId && s.projectId === projectId);
+        if (!status) {
+          return send(res, 400, { error: 'invalid status' });
+        }
+        task.statusId = status.id;
+      }
+      return send(res, 200, task);
+    } catch (err) {
+      return send(res, 400, { error: 'invalid json' });
+    }
+  }
+
+  if (singleTaskMatch && req.method === 'DELETE') {
+    const user = authenticate(req);
+    if (!user) {
+      return send(res, 401, { error: 'unauthorized' });
+    }
+    const projectId = parseInt(singleTaskMatch[1], 10);
+    const taskId = parseInt(singleTaskMatch[2], 10);
+    const project = projects.find(p => p.id === projectId && p.members.includes(user.id));
+    if (!project) {
+      return send(res, 404, { error: 'project not found' });
+    }
+    const index = tasks.findIndex(t => t.id === taskId && t.projectId === projectId);
+    if (index === -1) {
+      return send(res, 404, { error: 'task not found' });
+    }
+    tasks.splice(index, 1);
+    res.writeHead(204);
+    return res.end();
+  }
+
+  const taskSubtasksMatch = req.url.match(/^\/projects\/(\d+)\/tasks\/(\d+)\/subtasks$/);
+  if (taskSubtasksMatch && req.method === 'POST') {
+    const user = authenticate(req);
+    if (!user) {
+      return send(res, 401, { error: 'unauthorized' });
+    }
+    const projectId = parseInt(taskSubtasksMatch[1], 10);
+    const taskId = parseInt(taskSubtasksMatch[2], 10);
+    const project = projects.find(p => p.id === projectId && p.members.includes(user.id));
+    if (!project) {
+      return send(res, 404, { error: 'project not found' });
+    }
+    const task = tasks.find(t => t.id === taskId && t.projectId === projectId);
+    if (!task) {
+      return send(res, 404, { error: 'task not found' });
+    }
+    try {
+      const body = await parseBody(req);
+      const { title } = body;
+      if (!title) {
+        return send(res, 400, { error: 'title required' });
+      }
+      const subtask = { id: nextSubtaskId++, taskId, title, completed: false };
+      subtasks.push(subtask);
+      return send(res, 201, subtask);
+    } catch (err) {
+      return send(res, 400, { error: 'invalid json' });
+    }
+  }
+
+  if (taskSubtasksMatch && req.method === 'GET') {
+    const user = authenticate(req);
+    if (!user) {
+      return send(res, 401, { error: 'unauthorized' });
+    }
+    const projectId = parseInt(taskSubtasksMatch[1], 10);
+    const taskId = parseInt(taskSubtasksMatch[2], 10);
+    const project = projects.find(p => p.id === projectId && p.members.includes(user.id));
+    if (!project) {
+      return send(res, 404, { error: 'project not found' });
+    }
+    const task = tasks.find(t => t.id === taskId && t.projectId === projectId);
+    if (!task) {
+      return send(res, 404, { error: 'task not found' });
+    }
+    const taskSubtasks = subtasks.filter(s => s.taskId === taskId);
+    return send(res, 200, taskSubtasks);
+  }
+
+  const singleSubtaskMatch = req.url.match(/^\/projects\/(\d+)\/tasks\/(\d+)\/subtasks\/(\d+)$/);
+  if (singleSubtaskMatch && req.method === 'PATCH') {
+    const user = authenticate(req);
+    if (!user) {
+      return send(res, 401, { error: 'unauthorized' });
+    }
+    const projectId = parseInt(singleSubtaskMatch[1], 10);
+    const taskId = parseInt(singleSubtaskMatch[2], 10);
+    const subtaskId = parseInt(singleSubtaskMatch[3], 10);
+    const project = projects.find(p => p.id === projectId && p.members.includes(user.id));
+    if (!project) {
+      return send(res, 404, { error: 'project not found' });
+    }
+    const task = tasks.find(t => t.id === taskId && t.projectId === projectId);
+    if (!task) {
+      return send(res, 404, { error: 'task not found' });
+    }
+    const subtask = subtasks.find(s => s.id === subtaskId && s.taskId === taskId);
+    if (!subtask) {
+      return send(res, 404, { error: 'subtask not found' });
+    }
+    try {
+      const body = await parseBody(req);
+      if (body.title !== undefined) {
+        subtask.title = body.title;
+      }
+      if (body.completed !== undefined) {
+        subtask.completed = !!body.completed;
+      }
+      return send(res, 200, subtask);
+    } catch (err) {
+      return send(res, 400, { error: 'invalid json' });
+    }
+  }
+
+  if (singleSubtaskMatch && req.method === 'DELETE') {
+    const user = authenticate(req);
+    if (!user) {
+      return send(res, 401, { error: 'unauthorized' });
+    }
+    const projectId = parseInt(singleSubtaskMatch[1], 10);
+    const taskId = parseInt(singleSubtaskMatch[2], 10);
+    const subtaskId = parseInt(singleSubtaskMatch[3], 10);
+    const project = projects.find(p => p.id === projectId && p.members.includes(user.id));
+    if (!project) {
+      return send(res, 404, { error: 'project not found' });
+    }
+    const task = tasks.find(t => t.id === taskId && t.projectId === projectId);
+    if (!task) {
+      return send(res, 404, { error: 'task not found' });
+    }
+    const index = subtasks.findIndex(s => s.id === subtaskId && s.taskId === taskId);
+    if (index === -1) {
+      return send(res, 404, { error: 'subtask not found' });
+    }
+    subtasks.splice(index, 1);
+    res.writeHead(204);
+    return res.end();
+  }
+
+  const taskCommentsMatch = req.url.match(/^\/projects\/(\d+)\/tasks\/(\d+)\/comments$/);
+  if (taskCommentsMatch && req.method === 'POST') {
+    const user = authenticate(req);
+    if (!user) {
+      return send(res, 401, { error: 'unauthorized' });
+    }
+    const projectId = parseInt(taskCommentsMatch[1], 10);
+    const taskId = parseInt(taskCommentsMatch[2], 10);
+    const project = projects.find(p => p.id === projectId && p.members.includes(user.id));
+    if (!project) {
+      return send(res, 404, { error: 'project not found' });
+    }
+    const task = tasks.find(t => t.id === taskId && t.projectId === projectId);
+    if (!task) {
+      return send(res, 404, { error: 'task not found' });
+    }
+    try {
+      const body = await parseBody(req);
+      const { text } = body;
+      if (!text) {
+        return send(res, 400, { error: 'text required' });
+      }
+      const comment = { id: nextCommentId++, taskId, userId: user.id, text };
+      comments.push(comment);
+      return send(res, 201, comment);
+    } catch (err) {
+      return send(res, 400, { error: 'invalid json' });
+    }
+  }
+
+  if (taskCommentsMatch && req.method === 'GET') {
+    const user = authenticate(req);
+    if (!user) {
+      return send(res, 401, { error: 'unauthorized' });
+    }
+    const projectId = parseInt(taskCommentsMatch[1], 10);
+    const taskId = parseInt(taskCommentsMatch[2], 10);
+    const project = projects.find(p => p.id === projectId && p.members.includes(user.id));
+    if (!project) {
+      return send(res, 404, { error: 'project not found' });
+    }
+    const task = tasks.find(t => t.id === taskId && t.projectId === projectId);
+    if (!task) {
+      return send(res, 404, { error: 'task not found' });
+    }
+    const taskComments = comments.filter(c => c.taskId === taskId);
+    return send(res, 200, taskComments);
+  }
+
+  const singleCommentMatch = req.url.match(/^\/projects\/(\d+)\/tasks\/(\d+)\/comments\/(\d+)$/);
+  if (singleCommentMatch && req.method === 'PATCH') {
+    const user = authenticate(req);
+    if (!user) {
+      return send(res, 401, { error: 'unauthorized' });
+    }
+    const projectId = parseInt(singleCommentMatch[1], 10);
+    const taskId = parseInt(singleCommentMatch[2], 10);
+    const commentId = parseInt(singleCommentMatch[3], 10);
+    const project = projects.find(p => p.id === projectId && p.members.includes(user.id));
+    if (!project) {
+      return send(res, 404, { error: 'project not found' });
+    }
+    const task = tasks.find(t => t.id === taskId && t.projectId === projectId);
+    if (!task) {
+      return send(res, 404, { error: 'task not found' });
+    }
+    const comment = comments.find(c => c.id === commentId && c.taskId === taskId);
+    if (!comment) {
+      return send(res, 404, { error: 'comment not found' });
+    }
+    if (comment.userId !== user.id) {
+      return send(res, 403, { error: 'forbidden' });
+    }
+    try {
+      const body = await parseBody(req);
+      if (body.text !== undefined) {
+        comment.text = body.text;
+      }
+      return send(res, 200, comment);
+    } catch (err) {
+      return send(res, 400, { error: 'invalid json' });
+    }
+  }
+
+  if (singleCommentMatch && req.method === 'DELETE') {
+    const user = authenticate(req);
+    if (!user) {
+      return send(res, 401, { error: 'unauthorized' });
+    }
+    const projectId = parseInt(singleCommentMatch[1], 10);
+    const taskId = parseInt(singleCommentMatch[2], 10);
+    const commentId = parseInt(singleCommentMatch[3], 10);
+    const project = projects.find(p => p.id === projectId && p.members.includes(user.id));
+    if (!project) {
+      return send(res, 404, { error: 'project not found' });
+    }
+    const task = tasks.find(t => t.id === taskId && t.projectId === projectId);
+    if (!task) {
+      return send(res, 404, { error: 'task not found' });
+    }
+    const index = comments.findIndex(c => c.id === commentId && c.taskId === taskId);
+    if (index === -1) {
+      return send(res, 404, { error: 'comment not found' });
+    }
+    if (comments[index].userId !== user.id) {
+      return send(res, 403, { error: 'forbidden' });
+    }
+    comments.splice(index, 1);
+    res.writeHead(204);
+    return res.end();
+  }
+
+  return send(res, 404, { error: 'Not found' });
+};
+
+if (require.main === module) {
+  const PORT = process.env.PORT || 3000;
+  http.createServer(requestListener).listen(PORT, () => {
+    console.log(`Server listening on port ${PORT}`);
+  });
+}
+
+module.exports = requestListener;

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Project Manager</title>
+  <style>
+    body { font-family: sans-serif; max-width: 800px; margin: 0 auto; padding: 1rem; }
+    form { margin-bottom: 1rem; }
+    input { margin-right: 0.5rem; }
+    ul { list-style: none; padding-left: 0; }
+    li { cursor: pointer; margin: 0.25rem 0; }
+    #app, #projectDetail { display: none; }
+  </style>
+</head>
+<body>
+  <h1>Project Manager Frontend</h1>
+
+  <div id="auth">
+    <h2>Register</h2>
+    <form id="registerForm">
+      <input name="username" placeholder="username" required>
+      <input name="password" type="password" placeholder="password" required>
+      <button>Register</button>
+    </form>
+
+    <h2>Login</h2>
+    <form id="loginForm">
+      <input name="username" placeholder="username" required>
+      <input name="password" type="password" placeholder="password" required>
+      <button>Login</button>
+    </form>
+  </div>
+
+  <div id="app">
+    <button id="logoutBtn">Logout</button>
+
+    <h2>Create Project</h2>
+    <form id="projectForm">
+      <input name="name" placeholder="project name" required>
+      <button>Add</button>
+    </form>
+
+    <h2>Your Projects</h2>
+    <ul id="projectList"></ul>
+
+    <div id="projectDetail">
+      <h3>Tasks for <span id="projectTitle"></span></h3>
+      <form id="taskForm">
+        <input name="title" placeholder="task title" required>
+        <button>Add</button>
+      </form>
+      <ul id="taskList"></ul>
+    </div>
+  </div>
+
+  <script type="module" src="./src/main.js"></script>
+</body>
+</html>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -48,6 +48,7 @@
       <h3>Tasks for <span id="projectTitle"></span></h3>
       <form id="taskForm">
         <input name="title" placeholder="task title" required>
+        <input type="date" name="dueDate">
         <button>Add</button>
       </form>
       <ul id="taskList"></ul>

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "frontend",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "frontend",
+  "version": "1.0.0",
+  "description": "Project management frontend",
+  "main": "src/main.js",
+  "type": "module",
+  "scripts": {
+    "start": "node server.cjs",
+    "test": "echo \"No tests\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/frontend/server.cjs
+++ b/frontend/server.cjs
@@ -1,0 +1,30 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const serveFile = (res, filePath, type) => {
+  fs.readFile(filePath, (err, data) => {
+    if (err) {
+      res.writeHead(404);
+      return res.end('Not found');
+    }
+    res.writeHead(200, { 'Content-Type': type });
+    res.end(data);
+  });
+};
+
+const server = http.createServer((req, res) => {
+  if (req.url === '/' || req.url === '/index.html') {
+    return serveFile(res, path.join(__dirname, 'index.html'), 'text/html');
+  }
+  if (req.url === '/src/main.js') {
+    return serveFile(res, path.join(__dirname, 'src', 'main.js'), 'application/javascript');
+  }
+  res.writeHead(404);
+  res.end('Not found');
+});
+
+const PORT = process.env.PORT || 8080;
+server.listen(PORT, () => {
+  console.log(`Frontend running on http://localhost:${PORT}`);
+});

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -98,7 +98,7 @@ async function loadTasks() {
   taskListEl.innerHTML = '';
   tasks.forEach(t => {
     const li = document.createElement('li');
-    li.textContent = t.title + (t.completed ? ' \u2714' : '');
+    li.textContent = t.title + (t.dueDate ? ` (${t.dueDate})` : '') + (t.completed ? ' \u2714' : '');
     taskListEl.appendChild(li);
   });
 }
@@ -109,7 +109,7 @@ document.getElementById('taskForm').addEventListener('submit', async e => {
   await fetch(`/api/projects/${currentProjectId}/tasks`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-    body: JSON.stringify({ title: form.title.value })
+    body: JSON.stringify({ title: form.title.value, dueDate: form.dueDate.value || undefined })
   });
   form.reset();
   loadTasks();

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -1,0 +1,139 @@
+let token = localStorage.getItem('token');
+let currentProjectId = null;
+
+const authSection = document.getElementById('auth');
+const appSection = document.getElementById('app');
+const projectDetail = document.getElementById('projectDetail');
+const projectTitle = document.getElementById('projectTitle');
+const projectListEl = document.getElementById('projectList');
+const taskListEl = document.getElementById('taskList');
+
+function setToken(newToken) {
+  token = newToken;
+  if (token) localStorage.setItem('token', token);
+  else localStorage.removeItem('token');
+}
+
+function updateUI() {
+  if (token) {
+    authSection.style.display = 'none';
+    appSection.style.display = 'block';
+    loadProjects();
+  } else {
+    authSection.style.display = 'block';
+    appSection.style.display = 'none';
+    projectDetail.style.display = 'none';
+  }
+}
+
+document.getElementById('registerForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const form = e.target;
+  await fetch('/api/auth/register', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: form.username.value, password: form.password.value })
+  });
+  form.reset();
+  alert('Registered! Now log in.');
+});
+
+document.getElementById('loginForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const form = e.target;
+  const res = await fetch('/api/auth/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: form.username.value, password: form.password.value })
+  });
+  if (res.ok) {
+    const data = await res.json();
+    setToken(data.token);
+    updateUI();
+  } else {
+    alert('Login failed');
+  }
+});
+
+document.getElementById('logoutBtn').addEventListener('click', async () => {
+  await fetch('/api/auth/logout', { method: 'POST', headers: { Authorization: `Bearer ${token}` } });
+  setToken(null);
+  updateUI();
+});
+
+async function loadProjects() {
+  const res = await fetch('/api/projects', { headers: { Authorization: `Bearer ${token}` } });
+  const projects = await res.json();
+  projectListEl.innerHTML = '';
+  projects.forEach(p => {
+    const li = document.createElement('li');
+    li.textContent = p.name;
+    li.addEventListener('click', () => selectProject(p));
+    projectListEl.appendChild(li);
+  });
+}
+
+document.getElementById('projectForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const form = e.target;
+  await fetch('/api/projects', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ name: form.name.value })
+  });
+  form.reset();
+  loadProjects();
+});
+
+function selectProject(project) {
+  currentProjectId = project.id;
+  projectTitle.textContent = project.name;
+  projectDetail.style.display = 'block';
+  loadTasks();
+}
+
+async function loadTasks() {
+  const res = await fetch(`/api/projects/${currentProjectId}/tasks`, { headers: { Authorization: `Bearer ${token}` } });
+  const tasks = await res.json();
+  taskListEl.innerHTML = '';
+  tasks.forEach(t => {
+    const li = document.createElement('li');
+    li.textContent = t.title + (t.completed ? ' \u2714' : '');
+    taskListEl.appendChild(li);
+  });
+}
+
+document.getElementById('taskForm').addEventListener('submit', async e => {
+  e.preventDefault();
+  const form = e.target;
+  await fetch(`/api/projects/${currentProjectId}/tasks`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify({ title: form.title.value })
+  });
+  form.reset();
+  loadTasks();
+});
+
+fetch('/api')
+  .then(r => r.json())
+  .then(data => console.log('API says:', data))
+  .catch(err => console.error('API error', err));
+
+if (token) {
+  fetch('/api/auth/me', { headers: { Authorization: `Bearer ${token}` } })
+    .then(r => {
+      if (!r.ok) throw new Error();
+      return r.json();
+    })
+    .then(data => {
+      console.log('Logged in as:', data);
+      updateUI();
+    })
+    .catch(() => {
+      setToken(null);
+      updateUI();
+    });
+} else {
+  updateUI();
+}

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -120,20 +120,19 @@ fetch('/api')
   .then(data => console.log('API says:', data))
   .catch(err => console.error('API error', err));
 
+// Render the appropriate section immediately
+updateUI();
+
+// Verify any stored token without blocking the initial render
 if (token) {
   fetch('/api/auth/me', { headers: { Authorization: `Bearer ${token}` } })
     .then(r => {
       if (!r.ok) throw new Error();
       return r.json();
     })
-    .then(data => {
-      console.log('Logged in as:', data);
-      updateUI();
-    })
+    .then(data => console.log('Logged in as:', data))
     .catch(() => {
       setToken(null);
       updateUI();
     });
-} else {
-  updateUI();
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "project-management-app",
+  "private": true,
+  "scripts": {
+    "install:all": "npm --prefix backend install && npm --prefix frontend install",
+    "test": "npm --prefix backend test && npm --prefix frontend test",
+    "start": "npm --prefix backend start & npm --prefix frontend start"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "project-management-app",
+  "version": "1.0.0",
   "private": true,
+  "description": "Full-stack project management application",
+  "license": "MIT",
   "scripts": {
     "install:all": "npm --prefix backend install && npm --prefix frontend install",
     "test": "npm --prefix backend test && npm --prefix frontend test",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "install:all": "npm --prefix backend install && npm --prefix frontend install",
     "test": "npm --prefix backend test && npm --prefix frontend test",
-    "start": "npm --prefix backend start & npm --prefix frontend start"
+    "start": "npm --prefix backend start & npm --prefix frontend start",
+    "deploy": "npm run install:all && npx vercel --prod"
   }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,11 @@
+{
+  "version": 2,
+  "builds": [
+    { "src": "api/index.js", "use": "@vercel/node" },
+    { "src": "frontend/**", "use": "@vercel/static" }
+  ],
+  "routes": [
+    { "src": "/api/(.*)", "dest": "/api/index.js" },
+    { "src": "/(.*)", "dest": "/frontend/$1" }
+  ]
+}


### PR DESCRIPTION
## Summary
- provide HTML interface for registering, logging in, creating projects, and adding tasks
- hook frontend requests to backend via relative `/api` path and document usage

## Testing
- `npm test`
- `curl -s http://localhost:3000/`
- `curl -s http://localhost:8080/ | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68c1151f45cc832d9326526bee8bcd8c